### PR TITLE
Updated Box Shadow for Project Cards

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -18,7 +18,7 @@ const {
     text-decoration: none;
     border-radius: 12px;
     overflow: hidden;
-    box-shadow: 0 4px 10px rgba(211, 193, 193, 0.1);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     background: white;
     margin: 20px;


### PR DESCRIPTION
- updated box shadow for project cards to make forms more distinguishable

Cards now look like this:

<img width="440" height="300" alt="image" src="https://github.com/user-attachments/assets/357de3b3-18b6-4126-bc9c-c8e48b081fbc" />
